### PR TITLE
django-uwsgi-nginx: use dynamic wsgi module name

### DIFF
--- a/ubuntu/django-uwsgi-nginx/uwsgi.ini
+++ b/ubuntu/django-uwsgi-nginx/uwsgi.ini
@@ -26,6 +26,6 @@ home=/Users/you/envs/env
 chdir = %dapp/
 # load the module from wsgi.py, it is a python path from 
 # the directory above.
-module=website.wsgi:application
+module=%s.wsgi:application
 # allow anyone to connect to the socket. This is very permissive
 chmod-socket=666


### PR DESCRIPTION
"website" was harcoded, using `%d` will use the current directory name
