### PR TITLE
fix for docker overlay network

### DIFF
--- a/ubuntu/pgbouncer/Dockerfile
+++ b/ubuntu/pgbouncer/Dockerfile
@@ -1,13 +1,59 @@
 FROM ubuntu
 MAINTAINER Matt Bentley <mbentley@mbentley.net> and Gaurang Vyas <gdvyas@gmail.com>
-RUN (echo "deb http://archive.ubuntu.com/ubuntu/ trusty main restricted universe multiverse" > /etc/apt/sources.list && echo "deb http://archive.ubuntu.com/ubuntu/ trusty-updates main restricted universe multiverse" >> /etc/apt/sources.list && echo "deb http://archive.ubuntu.com/ubuntu/ trusty-backports main restricted universe multiverse" >> /etc/apt/sources.list && echo "deb http://archive.ubuntu.com/ubuntu/ trusty-security main restricted universe multiverse" >> /etc/apt/sources.list)
-RUN apt-get update
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y install wget
-RUN wget --quiet --no-check-certificate -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main" > /etc/apt/sources.list.d/pgdg.list
-RUN apt-get update
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y install pgbouncer net-tools vim
+RUN apt-get update \
+    && apt-get -y --no-install-recommends install \
+        automake \
+        build-essential \
+        ca-certificates \
+        git \
+        libc-ares2 \
+        libc-ares-dev \
+        libev4 \
+        libev-dev \
+        libevent-2.0-5 \
+        libevent-dev \
+        libssl1.0.0 \
+        libssl-dev \
+        libtool \
+        pkg-config \
+        wget \
+    && mkdir -p /opt && cd /opt \
+    && git clone https://github.com/pgbouncer/pgbouncer.git \
+    && cd /opt/pgbouncer \
+    && git checkout pgbouncer_1_7_2 \
+    && git submodule init \
+    && git submodule update \
+    && ./autogen.sh \
+    && ./configure --enable-evdns=no \
+    && make \
+    && make install \
+    && apt-get remove -y \
+        automake \
+        build-essential \
+        ca-certificates \
+        git \
+        libc-ares-dev \
+        libev-dev \
+        libevent-dev \
+        libssl-dev \
+        libtool \
+        pkg-config \
+        wget \
+    && apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+## After `make install` pgbouncer needs some extra touches to make it work
+RUN mkdir -p /etc/pgbouncer/
+RUN mkdir -p /var/run/postgresql/
+RUN mkdir -p /var/log/postgresql/
+RUN groupadd --system postgres
+RUN useradd -g postgres postgres
+RUN touch /var/log/postgresql
+RUN chown postgres:postgres /var/log/postgresql
+RUN chown postgres:postgres /var/run/postgresql/
+
+
+
 ENV PG_ENV_POSTGRESQL_MAX_CLIENT_CONN 10000
 ENV PG_ENV_POSTGRESQL_DEFAULT_POOL_SIZE 400
 ENV PG_ENV_POSTGRESQL_SERVER_IDLE_TIMEOUT 240

--- a/ubuntu/pgbouncer/Dockerfile
+++ b/ubuntu/pgbouncer/Dockerfile
@@ -40,19 +40,15 @@ RUN apt-get update \
         libtool \
         pkg-config \
         wget \
-    && apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/*
-
-## After `make install` pgbouncer needs some extra touches to make it work
-RUN mkdir -p /etc/pgbouncer/
-RUN mkdir -p /var/run/postgresql/
-RUN mkdir -p /var/log/postgresql/
-RUN groupadd --system postgres
-RUN useradd -g postgres postgres
-RUN touch /var/log/postgresql
-RUN chown postgres:postgres /var/log/postgresql
-RUN chown postgres:postgres /var/run/postgresql/
-
-
+    && apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /etc/pgbouncer/ \
+    && mkdir -p /var/run/postgresql/ \
+    && mkdir -p /var/log/postgresql/ \
+    && groupadd --system postgres \
+    && useradd -g postgres postgres \
+    && touch /var/log/postgresql \
+    && chown postgres:postgres /var/log/postgresql \
+    && chown postgres:postgres /var/run/postgresql
 
 ENV PG_ENV_POSTGRESQL_MAX_CLIENT_CONN 10000
 ENV PG_ENV_POSTGRESQL_DEFAULT_POOL_SIZE 400

--- a/ubuntu/pgbouncer/run.sh
+++ b/ubuntu/pgbouncer/run.sh
@@ -48,4 +48,4 @@ chown root:postgres /var/log/postgresql
 chmod 1775 /var/log/postgresql
 chmod 640 /etc/pgbouncer/userlist.txt
 
-/usr/sbin/pgbouncer -u postgres /etc/pgbouncer/pgbconf.ini
+pgbouncer -u postgres /etc/pgbouncer/pgbconf.ini


### PR DESCRIPTION
so, this is quite a large change so no ill feeling if you don't accept the pull.

the change was needed into our environment to fix the default dns clib in pgbouncer not resolving dns names as provided by docker swarm mode/docker overlay network, as discovered here https://github.com/pgbouncer/pgbouncer/issues/122